### PR TITLE
Remove __osx constraint

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: bb6bf4f534b9559cf123dcdc6f9cd8167de950314a90a88b2a329c16836e7f6c
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win]
   run_exports:
     - {{ pin_subpackage('nspr', max_pin='x') }}
@@ -22,9 +22,6 @@ requirements:
     - make
     - autoconf
     - sed
-  # https://github.com/Quansight/omnisci/issues/20#issuecomment-422294770
-  run_constrained:
-    - __osx >={{ MACOSX_DEPLOYMENT_TARGET|default("10.13") }}  # [osx]
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ requirements:
   # https://github.com/Quansight/omnisci/issues/20#issuecomment-422294770
   run_constrained:
     - __osx >={{ MACOSX_DEPLOYMENT_TARGET|default("10.13") }}  # [osx and target_platform != 'osx-arm64']
-    
+
 test:
   commands:
     - test -f ${PREFIX}/lib/libnspr4${SHLIB_EXT}         # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,10 @@ requirements:
     - make
     - autoconf
     - sed
-
+  # https://github.com/Quansight/omnisci/issues/20#issuecomment-422294770
+  run_constrained:
+    - __osx >={{ MACOSX_DEPLOYMENT_TARGET|default("10.13") }}  # [osx and target_platform != 'osx-arm64']
+    
 test:
   commands:
     - test -f ${PREFIX}/lib/libnspr4${SHLIB_EXT}         # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,9 +22,6 @@ requirements:
     - make
     - autoconf
     - sed
-  # https://github.com/Quansight/omnisci/issues/20#issuecomment-422294770
-  run_constrained:
-    - __osx >={{ MACOSX_DEPLOYMENT_TARGET|default("10.13") }}  # [osx and target_platform != 'osx-arm64']
 
 test:
   commands:


### PR DESCRIPTION
It may be that this is no longer needed (the issue that the associated comment refers to is over 3 years old) and it is causing trouble in cross-compiling for `osx-arm64`.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

closes #22 